### PR TITLE
stack_c_amd64.c: fix typo in comment

### DIFF
--- a/src/stack_c_amd64.c
+++ b/src/stack_c_amd64.c
@@ -1004,7 +1004,7 @@ int main(int argc, char *argv[])
 		}
 		else if (sym == SYM_GE_SIGNED)
 		{
-			fprintf(fout, "\tpop_rbx               # >=sfv\n\tcmp_rbx,rax\n\tsetge_al\n\tmovzx_rax,al\n");
+			fprintf(fout, "\tpop_rbx               # >=s\n\tcmp_rbx,rax\n\tsetge_al\n\tmovzx_rax,al\n");
 		}
 		else if (sym == SYM_SHL)
 		{


### PR DESCRIPTION
Fix a minor typo in a generated comment, make it consistent with above.