### PR TITLE
tcc_cc.c: fix issue with 64-bit arithmetic

### DIFF
--- a/src/tcc_cc.c
+++ b/src/tcc_cc.c
@@ -4375,6 +4375,18 @@ void expr_print_warning(expr_p expr, const char *mesg)
 	}
 }
 
+void gen_canon_narrow(expr_p expr, expr_p operand)
+{
+	if (long_long_size != TARGET_64BITS)
+		return;
+	if (operand == NULL || !type_is_integer(operand->type) || operand->type->size != 4)
+		return;
+	if (type_is_signed_integer(expr->children[0]->type) || type_is_signed_integer(expr->children[1]->type))
+		fprintf(fcode, "long ");
+	else
+		fprintf(fcode, "0xFFFFFFFF & ");
+}
+
 void gen_expr(expr_p expr, bool as_value)
 {
 	if (expr == NULL)
@@ -4554,7 +4566,9 @@ void gen_expr(expr_p expr, bool as_value)
 		case TK_LE:
 		case TK_GE:
 			gen_expr(expr->children[0], TRUE);
+			gen_canon_narrow(expr, expr->children[0]);
 			gen_expr(expr->children[1], TRUE);
+			gen_canon_narrow(expr, expr->children[1]);
 			switch (expr->kind)
 			{
 				case TK_LE: fprintf(fcode, "<="); break;

--- a/src/unittest.c
+++ b/src/unittest.c
@@ -234,6 +234,12 @@ int main (int argc, char *argv[])
 	v_func();
 	int array[] = { 1, 2, 3 };
 	is_true(sizeof(array) == 3 * sizeof(array[0]), "size of array is 3");
+
+	unsigned int low = 0;
+	unsigned int high = 0xFFFFFFF8;
+	int limit = 4;
+	is_true((low - high) > limit, "32-bit subtraction result in ordered compare");
+
 	static int s_int = 1;
 	is_true(s_int == 1, "static int == 1");
 	


### PR DESCRIPTION
The value of `0 - 0xFFFFFFF8` should be 8 with unsigned 32-bit integers,
but is computed in 64-bit as 0xFFFFFFFF00000008, which when used in
comparison with a signed int causes problems.  Fix by truncating to
32-bits.

Not sure if this is a clean implementation.

This is problematic for https://gitlab.com/janneke/tinycc/-/blob/mes-0.27/tccgen.c?ref_type=heads&blame=1#L6252-6253
